### PR TITLE
*: import from github.com/simonpasquier/prometheus-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2.1
+
+orbs:
+  orb-tools: circleci/orb-tools@8.23.1
+
+workflows:
+  build:
+    jobs:
+      - orb-tools/lint
+      - orb-tools/pack:
+          filters:
+            tags:
+              only: /.*/
+      - orb-tools/publish-dev:
+          orb-name: prometheus/prometheus
+          publish-token-variable: CIRCLECI_API_TOKEN
+          requires:
+          - orb-tools/lint
+          - orb-tools/pack
+          filters:
+            branches:
+              only: master
+      - orb-tools/publish:
+          orb-ref: prometheus/prometheus@$CIRCLE_TAG
+          publish-token-variable: CIRCLECI_API_TOKEN
+          checkout: false
+          attach-workspace: true
+          requires:
+          - orb-tools/pack
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+){2}$/
+            branches:
+              ignore: /.*/

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,1 @@
+* Simon Pasquier <pasquier.simon@gmail.com>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,0 +1,5 @@
+version: 2.1
+
+description: |
+  Orb for building and publishing Prometheus artefacts. Full orb
+  source code: https://github.com/prometheus/circleci

--- a/src/commands/check_proto.yml
+++ b/src/commands/check_proto.yml
@@ -1,0 +1,19 @@
+description: >
+  Check that the protobuf generated code is up-to-date.
+
+parameters:
+  version:
+    description: protoc version
+    type: string
+    default: "3.5.1"
+
+steps:
+- run:
+   command: |
+     curl -s -L https://github.com/protocolbuffers/protobuf/releases/download/v<< parameters.version >>/protoc-<< parameters.version >>-linux-x86_64.zip > /tmp/protoc.zip
+     unzip -d /tmp /tmp/protoc.zip
+     chmod +x /tmp/bin/protoc
+     echo 'export PATH=/tmp/bin:$PATH' >> $BASH_ENV
+     source $BASH_ENV
+     make proto
+- run: git diff --exit-code

--- a/src/commands/publish_images.yml
+++ b/src/commands/publish_images.yml
@@ -1,0 +1,23 @@
+description: >
+  Build and publish images to a container image registry.
+
+parameters:
+  registry:
+    description: Registry address
+    type: string
+  organization:
+    description: Registry organization
+    type: string
+  login_variable:
+    description: Environment variable holding the registry login
+    type: env_var_name
+  password_variable:
+    description: Environment variable holding the registry password
+    type: env_var_name
+
+steps:
+- run: make docker DOCKER_REPO=<< parameters.registry >>/<< parameters.organization >>
+- run: docker images
+- run: docker login -u $<< parameters.login_variable >> -p $<< parameters.password_variable >> << parameters.registry >>
+- run: make docker-publish DOCKER_REPO=<< parameters.registry >>/<< parameters.organization >>
+- run: make docker-manifest DOCKER_REPO=<< parameters.registry >>/<< parameters.organization >>

--- a/src/commands/publish_release_images.yml
+++ b/src/commands/publish_release_images.yml
@@ -1,0 +1,29 @@
+description: >
+  Build and publish release images to a container image registry.
+
+parameters:
+  registry:
+    description: Registry address
+    type: string
+  organization:
+    description: Registry organization
+    type: string
+  login_variable:
+    description: Environment variable holding the registry login
+    type: env_var_name
+  password_variable:
+    description: Environment variable holding the registry password
+    type: env_var_name
+
+steps:
+- run: make docker DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=<< parameters.registry >>/<< parameters.organization >>
+- run: docker images
+- run: docker login -u $<< parameters.login_variable >> -p $<< parameters.password_variable >> << parameters.registry >>
+- run: make docker-publish DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=<< parameters.registry >>/<< parameters.organization >>
+- run: make docker-manifest DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=<< parameters.registry >>/<< parameters.organization >>
+- run: |
+    if [[ "$CIRCLE_TAG" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
+      make docker-tag-latest DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=<< parameters.registry >>/<< parameters.organization >>
+      make docker-publish DOCKER_IMAGE_TAG="latest" DOCKER_REPO=<< parameters.registry >>/<< parameters.organization >>
+      make docker-manifest DOCKER_IMAGE_TAG="latest" DOCKER_REPO=<< parameters.registry >>/<< parameters.organization >>
+    fi

--- a/src/commands/setup_build_environment.yml
+++ b/src/commands/setup_build_environment.yml
@@ -1,0 +1,10 @@
+description: >
+  Setup the environment for building the container images.
+
+steps:
+- setup_environment
+- setup_remote_docker:
+    version: 18.06.0-ce
+- run: docker run --privileged linuxkit/binfmt:v0.6
+- attach_workspace:
+    at: .

--- a/src/commands/setup_environment.yml
+++ b/src/commands/setup_environment.yml
@@ -1,0 +1,6 @@
+description: >
+  Setup the minimal environment for the CI.
+
+steps:
+- checkout
+- run: make promu

--- a/src/commands/store_artifact.yml
+++ b/src/commands/store_artifact.yml
@@ -1,0 +1,17 @@
+description: >
+  Store a file as a build artifact.
+
+parameters:
+  file:
+    description: source file
+    type: string
+  directory:
+    description: destination directory
+    type: string
+    default: /build
+
+steps:
+- store_artifacts:
+    path: << parameters.file >>
+    destination: << parameters.directory >>/<< parameters.file >>
+- run: rm -v << parameters.file >>

--- a/src/executors/golang.yml
+++ b/src/executors/golang.yml
@@ -1,0 +1,14 @@
+description: >
+  Golang container executor
+
+parameters:
+  version:
+    description: Go version
+    type: string
+  resource_class:
+    description: Resource class
+    type: string
+
+resource_class: << parameters.resource_class >>
+docker:
+- image: circleci/golang:<< parameters.version >>

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -1,0 +1,16 @@
+description: >
+  Cross-build and store the binaries.
+
+machine:
+  enabled: true
+
+steps:
+- setup_environment
+- run: promu crossbuild -v
+- persist_to_workspace:
+    root: .
+    paths:
+    - .build
+- store_artifacts:
+    path: .build
+    destination: /build

--- a/src/jobs/publish_master.yml
+++ b/src/jobs/publish_master.yml
@@ -1,0 +1,18 @@
+description: >
+  Build and publish container images from the master branch.
+
+docker:
+- image: circleci/golang
+
+steps:
+- setup_build_environment
+- publish_images:
+    registry: docker.io
+    organization: prom
+    login_variable: DOCKER_LOGIN
+    password_variable: DOCKER_PASSWORD
+- publish_images:
+    registry: quay.io
+    organization: prometheus
+    login_variable: QUAY_LOGIN
+    password_variable: QUAY_PASSWORD

--- a/src/jobs/publish_release.yml
+++ b/src/jobs/publish_release.yml
@@ -1,0 +1,24 @@
+description: >
+  Build and publish binaries and container images for a given release tag.
+
+docker:
+- image: circleci/golang
+
+steps:
+- setup_build_environment
+- run: promu crossbuild tarballs
+- run: promu checksum .tarballs
+- run: promu release .tarballs
+- store_artifacts:
+    path: .tarballs
+    destination: releases
+- publish_release_images:
+    registry: docker.io
+    organization: prom
+    login_variable: DOCKER_LOGIN
+    password_variable: DOCKER_PASSWORD
+- publish_release_images:
+    registry: quay.io
+    organization: prometheus
+    login_variable: QUAY_LOGIN
+    password_variable: QUAY_PASSWORD

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -1,0 +1,25 @@
+description: >
+  Run 'make' and store the resulting binary.
+
+parameters:
+  version:
+    description: Go version
+    type: string
+  binary:
+    description: Binary name
+    type: string
+  resource_class:
+    description: Resource class
+    type: string
+    default: medium
+
+executor:
+  name: golang
+  version: << parameters.version >>
+  resource_class: << parameters.resource_class >>
+
+steps:
+- setup_environment
+- run: make
+- store_artifact:
+    file: << parameters.binary >>


### PR DESCRIPTION
This is basically the code I've played with in my own repository. When the code merges to `master`, the CI will push a [development version](https://circleci.com/docs/2.0/creating-orbs/#using-development-versions) of the orb and a Git tag will push an official version to the [Orb registry](https://circleci.com/orbs/registry/orb).

Before merging this initial PR, we need to create a Circle CI API token for prombot and add it to the project's [settings](https://circleci.com/gh/prometheus/circleci).