### PR TITLE
Update to linuxkit/binfmt v0.7

### DIFF
--- a/src/commands/setup_build_environment.yml
+++ b/src/commands/setup_build_environment.yml
@@ -5,6 +5,6 @@ steps:
 - setup_environment
 - setup_remote_docker:
     version: 18.06.0-ce
-- run: docker run --privileged linuxkit/binfmt:v0.6
+- run: docker run --privileged linuxkit/binfmt:v0.7
 - attach_workspace:
     at: .


### PR DESCRIPTION
We need a more recent version of `linuxkit/binfmt` for s390x images. See https://github.com/prometheus/prometheus/pull/6478#issuecomment-567346468 for context.