### PR TITLE
Add a build platform job

### DIFF
--- a/src/jobs/build_platform.yml
+++ b/src/jobs/build_platform.yml
@@ -1,0 +1,21 @@
+description: >
+  Cross-build and store the binaries for a specific platform regexp.
+
+machine:
+  enabled: true
+
+parameters:
+  platform:
+    type: string
+    description: A promu platform regexp to build.
+
+steps:
+- setup_environment
+- run: promu crossbuild -v -p '<< parameters.platform >>'
+- persist_to_workspace:
+    root: .
+    paths:
+    - .build
+- store_artifacts:
+    path: .build
+    destination: /build


### PR DESCRIPTION
Add a new job target "build_platform" to allow passing a platform
target to promu crossbuild. Useful to setup a parallel build matrix.

Signed-off-by: Ben Kochie <superq@gmail.com>