### PR TITLE
Update mixin test job

### DIFF
--- a/src/executors/golang.yml
+++ b/src/executors/golang.yml
@@ -5,9 +5,11 @@ parameters:
   version:
     description: Go version
     type: string
+    default: medium
   resource_class:
     description: Resource class
     type: string
+    default: "1.6"
 
 resource_class: << parameters.resource_class >>
 docker:

--- a/src/jobs/test_mixins.yml
+++ b/src/jobs/test_mixins.yml
@@ -4,18 +4,25 @@ description: >
 
 executor:
   name: golang
-  version: << parameters.version >>
   resource_class: << parameters.resource_class >>
+  version: << parameters.version >>
 
 parameters:
   mixin_path:
     description: Path to the mixin within the repo.
     default: monitoring-mixin
     type: string
+  mixtool_version:
+    description: The version of github.com/monitoring-mixins/mixtool to install
+    default: latest
+    type: string
+  jsonnetfmt_version:
+    description: The version of github.com/google/go-jsonnet to install
+    default: latest
+    type: string
   resource_class:
     description: Resource class
     type: string
-    default: medium
   version:
     description: Go version
     type: string
@@ -24,13 +31,7 @@ working_directory: ~/project/<< parameters.mixin_path >>
 
 steps:
 - setup_environment
-- run: >
-    go install -mod=readonly
-      github.com/google/go-jsonnet/cmd/jsonnet
-      github.com/google/go-jsonnet/cmd/jsonnetfmt
-      github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-      github.com/prometheus/prometheus/cmd/promtool
-- run: make clean
-- run: jb install
+- run: go install github.com/monitoring-mixins/mixtool/cmd/mixtool@<< parameters.mixtool_version >>
+- run: go install github.com/google/go-jsonnet/cmd/jsonnetfmt@<< parameters.jsonnetfmt_version >>
 - run: make
 - run: git diff --exit-code


### PR DESCRIPTION
* Switch to mixintool.
* Update install for Go 1.16.
* Simplify job.
* Set default Go version to 1.16.

Signed-off-by: Ben Kochie <superq@gmail.com>