### PR TITLE
Don't set a default Docker version for setup_remote_docker

### DIFF
--- a/src/jobs/publish_main.yml
+++ b/src/jobs/publish_main.yml
@@ -5,11 +5,11 @@ parameters:
   image:
     type: string
     description: Custom container image.
-    default: circleci/golang
+    default: cimg/go
   docker_version:
     type: string
     description: Docker version
-    default: 19.03.8
+    default: ""
   docker_hub_organization:
     type: string
     description: DockerHub organization

--- a/src/jobs/publish_master.yml
+++ b/src/jobs/publish_master.yml
@@ -5,11 +5,11 @@ parameters:
   image:
     type: string
     description: Custom container image.
-    default: circleci/golang
+    default: cimg/go
   docker_version:
     type: string
     description: Docker version
-    default: 19.03.8
+    default: ""
   docker_hub_organization:
     type: string
     description: DockerHub organization

--- a/src/jobs/publish_release.yml
+++ b/src/jobs/publish_release.yml
@@ -5,11 +5,11 @@ parameters:
   image:
     type: string
     description: Custom container image.
-    default: circleci/golang
+    default: cimg/go
   docker_version:
     type: string
     description: Docker version
-    default: 19.03.8
+    default: ""
   docker_hub_organization:
     type: string
     description: DockerHub organization


### PR DESCRIPTION
Pinning to a default version of Docker has triggered unexpected failures and the only solution was to bump the version in the project's CI configuration (see [1]).

[1] https://github.com/prometheus/alertmanager/pull/3177

Signed-off-by: Simon Pasquier <spasquie@redhat.com>