### PR TITLE
Fix image tag for cimg/go

### DIFF
--- a/src/jobs/publish_main.yml
+++ b/src/jobs/publish_main.yml
@@ -5,7 +5,7 @@ parameters:
   image:
     type: string
     description: Custom container image.
-    default: cimg/go
+    default: cimg/go:1.19
   docker_version:
     type: string
     description: Docker version

--- a/src/jobs/publish_master.yml
+++ b/src/jobs/publish_master.yml
@@ -5,7 +5,7 @@ parameters:
   image:
     type: string
     description: Custom container image.
-    default: cimg/go
+    default: cimg/go:1.19
   docker_version:
     type: string
     description: Docker version

--- a/src/jobs/publish_release.yml
+++ b/src/jobs/publish_release.yml
@@ -5,7 +5,7 @@ parameters:
   image:
     type: string
     description: Custom container image.
-    default: cimg/go
+    default: cimg/go:1.19
   docker_version:
     type: string
     description: Docker version


### PR DESCRIPTION
There is no `latest` tag for this so we need to select a specific Go version :/ We weren't using recent Go versions before #28 either however, since the old image didn't get updated anymore.

https://hub.docker.com/r/cimg/go/tags?page=1


@simonpasquier FYI